### PR TITLE
feat(S3.1): add GitHub and Google OAuth via Auth.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ GOOGLE_CLIENT_SECRET=
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_WS_URL=ws://localhost:8000
 
+# Server-side backend URL (NextAuth sync callback, Next.js rewrites)
+BACKEND_URL=http://localhost:8000
+
 # Sentry (Epic 7.4). Leave blank to disable.
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_DSN=

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import get_session
+from app.routers.auth import router as auth_router
 from app.routers.channels import router as channels_router
 from app.routers.dm import router as dm_router
 from app.routers.messages import router as messages_router
@@ -50,6 +51,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    app.include_router(auth_router, prefix="/api")
     app.include_router(channels_router, prefix="/api")
     app.include_router(dm_router, prefix="/api")
     app.include_router(messages_router, prefix="/api")

--- a/backend/src/app/routers/auth.py
+++ b/backend/src/app/routers/auth.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from app.config import get_settings
+from app.dependencies import SessionDep
+from app.schemas.auth import AuthSyncRequest, AuthSyncResponse
+from app.services.auth import create_access_token, upsert_oauth_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/sync", response_model=AuthSyncResponse)
+async def sync_user(
+    body: AuthSyncRequest,
+    session: SessionDep,
+) -> AuthSyncResponse:
+    """Upsert a user from an OAuth sign-in and return a backend JWT."""
+    settings = get_settings()
+    user = await upsert_oauth_user(session, body)
+    token = create_access_token(user, settings)
+    return AuthSyncResponse(user_id=user.id, access_token=token)

--- a/backend/src/app/schemas/auth.py
+++ b/backend/src/app/schemas/auth.py
@@ -1,0 +1,16 @@
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class AuthSyncRequest(BaseModel):
+    email: str = Field(min_length=3, max_length=255)
+    name: str = Field(min_length=1, max_length=255)
+    avatar_url: str | None = Field(default=None, max_length=2048)
+    provider: str = Field(min_length=1, max_length=64)
+    provider_id: str = Field(min_length=1, max_length=255)
+
+
+class AuthSyncResponse(BaseModel):
+    user_id: uuid.UUID
+    access_token: str

--- a/backend/src/app/services/auth.py
+++ b/backend/src/app/services/auth.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime, timedelta
+
+from jose import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import Settings
+from app.models.user import User
+from app.schemas.auth import AuthSyncRequest
+
+
+def create_access_token(user: User, settings: Settings) -> str:
+    """Mint a signed JWT with sub, email, and name for API/WebSocket auth."""
+    expire = datetime.now(UTC) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    payload = {
+        "sub": str(user.id),
+        "email": user.email,
+        "name": user.name,
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+async def upsert_oauth_user(session: AsyncSession, body: AuthSyncRequest) -> User:
+    """Find or create a user by OAuth provider identity, updating profile fields."""
+    result = await session.execute(
+        select(User).where(
+            User.provider == body.provider,
+            User.provider_id == body.provider_id,
+        )
+    )
+    user = result.scalars().first()
+
+    if user is None:
+        result = await session.execute(select(User).where(User.email == body.email))
+        user = result.scalars().first()
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    if user is None:
+        user = User(
+            email=body.email,
+            name=body.name,
+            avatar_url=body.avatar_url,
+            provider=body.provider,
+            provider_id=body.provider_id,
+        )
+        session.add(user)
+    else:
+        user.email = body.email
+        user.name = body.name
+        user.avatar_url = body.avatar_url
+        user.provider = body.provider
+        user.provider_id = body.provider_id
+        user.updated_at = now
+        session.add(user)
+
+    await session.commit()
+    await session.refresh(user)
+    return user

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,119 @@
+"""Tests for /api/auth/sync endpoint."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from jose import jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from tests.factories import UserFactory
+
+settings = get_settings()
+
+
+@pytest.mark.asyncio
+async def test_sync_creates_new_user(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/auth/sync",
+        json={
+            "email": "new@example.com",
+            "name": "New User",
+            "avatar_url": "https://example.com/avatar.png",
+            "provider": "github",
+            "provider_id": "12345",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "user_id" in data
+    assert "access_token" in data
+
+    user_id = uuid.UUID(data["user_id"])
+    payload = jwt.decode(
+        data["access_token"], settings.SECRET_KEY, algorithms=["HS256"]
+    )
+    assert payload["sub"] == str(user_id)
+    assert payload["email"] == "new@example.com"
+    assert payload["name"] == "New User"
+
+    me_response = await client.get(
+        "/api/users/me",
+        headers={"Authorization": f"Bearer {data['access_token']}"},
+    )
+    assert me_response.status_code == 200
+    me = me_response.json()
+    assert me["id"] == str(user_id)
+    assert me["email"] == "new@example.com"
+    assert me["name"] == "New User"
+
+
+@pytest.mark.asyncio
+async def test_sync_upserts_existing_provider_user(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    user = UserFactory.build(
+        email="old@example.com",
+        name="Old Name",
+        provider="github",
+        provider_id="999",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    response = await client.post(
+        "/api/auth/sync",
+        json={
+            "email": "updated@example.com",
+            "name": "Updated Name",
+            "avatar_url": "https://example.com/new.png",
+            "provider": "github",
+            "provider_id": "999",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] == str(user.id)
+
+    me_response = await client.get(
+        "/api/users/me",
+        headers={"Authorization": f"Bearer {data['access_token']}"},
+    )
+    assert me_response.status_code == 200
+    me = me_response.json()
+    assert me["email"] == "updated@example.com"
+    assert me["name"] == "Updated Name"
+    assert me["avatar_url"] == "https://example.com/new.png"
+
+
+@pytest.mark.asyncio
+async def test_sync_validation_error(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/auth/sync",
+        json={"email": "bad-email", "name": "x"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sync_token_works_with_protected_route(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/auth/sync",
+        json={
+            "email": "token@example.com",
+            "name": "Token User",
+            "avatar_url": None,
+            "provider": "google",
+            "provider_id": "oauth-1",
+        },
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+
+    me_response = await client.get(
+        "/api/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert me_response.status_code == 200
+    assert me_response.json()["email"] == "token@example.com"

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -16,7 +16,7 @@
 | Stories DONE / total    | 9 / 39     |
 | Currently IN_PROGRESS   | 0          |
 | Currently BLOCKED       | 0          |
-| Currently PARTIAL       | 2 (S3.1, S11.2) |
+| Currently PARTIAL       | 1 (S11.2) |
 
 ---
 
@@ -43,7 +43,7 @@
 
 | ID   | Status      | Notes                                                                |
 | ---- | ----------- | -------------------------------------------------------------------- |
-| S3.1 | PARTIAL     | `src/auth.ts` and `app/api/auth/[...nextauth]/route.ts` created — ClientFetchError fixed, session returns null cleanly. OAuth provider wiring (GitHub + Google) and backend `/api/auth/sync` JWT exchange remain TODO. |
+| S3.1 | DONE        | Auth.js v5 (GitHub + Google). JWT sessions. `signIn` callback upserts via `POST /api/auth/sync`. Backend JWT (`sub`, `email`, `name`) in `session.accessToken`. `middleware.ts` protects `/channels/*`. Sign-in page + sidebar sign-out. |
 | S3.2 | TODO        | Rate limiting + security headers.                                    |
 
 ## EPIC 4 — Real-time UX
@@ -134,7 +134,7 @@
 
 - `2026-06-14` — S2.4 DONE: Direct messages. `POST /api/dm` find-or-create, `GET /api/dm` list with other_user. `DMSection` in sidebar. `ChannelHeader` shows other user for DMs. "Send DM" in members panel avatar menu. `GET /api/channels` excludes `is_dm=true`. Backend tests in `test_dm.py`.
 - `2026-06-14` — S1.4 ENHANCED: Full-stack Docker Compose. `backend/Dockerfile` (python:3.12-slim, multi-stage, uv, `docker-entrypoint.sh` runs Alembic then uvicorn --reload), `frontend/Dockerfile` (node:20-alpine, multi-stage, npm ci, next dev). `docker-compose.yml` extended with `backend` and `frontend` services, healthchecks, `depends_on: service_healthy`, source bind-mounts for hot reload. `frontend/next.config.ts` uses `BACKEND_URL` env var for server-side API rewrite.
-- `2026-06-14` — S3.1 PARTIAL: Created `frontend/src/auth.ts` (NextAuth v5 config, conditional GitHub/Google providers) and `frontend/src/app/api/auth/[...nextauth]/route.ts` (route handler). `frontend/src/types/next-auth.d.ts` adds `session.accessToken` type. Fixes `ClientFetchError` on every page load — session now returns null cleanly until OAuth is wired.
+- `2026-06-14` — S3.1 DONE: OAuth auth (GitHub + Google). Backend `POST /api/auth/sync` upserts user, returns `{user_id, access_token}`. NextAuth `signIn`/`jwt`/`session` callbacks wire backend JWT. `middleware.ts` guards `/channels/*`. Sign-in page with provider buttons. `SidebarFooter` sign-out menu.
 - `2026-06-14` — S2.3 DONE: Full frontend chat UI. Three-panel layout, WS/Presence contexts, useMessages hook (infinite query + optimistic send), MessageList (react-virtual + day groups + infinite scroll + auto-scroll), MessageInput (auto-grow, emoji picker, send on Enter), TypingIndicator (animated dots), ChannelSidebar (active highlight, unread badge), MembersPanel (online/offline status). Vitest installed; 7 tests green; lint + typecheck pass.
 - `2026-05-22` — Agent governance bootstrap: AGENTS.md (root + submodules), `.cursor/rules/*`, `.cursorignore`, `docs/{BACKLOG,PROGRESS,ARCHITECTURE,OPERATIONS,CONVENTIONS}.md`, `.env.example`, `CONTRIBUTING.md`.
 - `2026-05-22` — Backend Phase 1–2 already implemented (HTTP API + WS gateway + tests).

--- a/frontend/src/app/auth/signin/page.tsx
+++ b/frontend/src/app/auth/signin/page.tsx
@@ -1,7 +1,21 @@
+import { SignInForm } from '@/components/auth/SignInForm'
+
 export default function SignInPage() {
+  const hasGitHub = Boolean(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET)
+  const hasGoogle = Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET)
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">Sign in</h1>
+    <main className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="w-full max-w-sm space-y-8 rounded-xl border bg-card p-8 shadow-sm">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">Welcome back</h1>
+          <p className="text-sm text-muted-foreground">
+            Sign in to continue to chat-engine
+          </p>
+        </div>
+
+        <SignInForm hasGitHub={hasGitHub} hasGoogle={hasGoogle} />
+      </div>
     </main>
   )
 }

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -2,13 +2,15 @@
  * Auth.js (NextAuth v5) configuration.
  *
  * OAuth providers are registered only when their env vars are set so the app
- * starts cleanly in dev without credentials. Full OAuth wiring (backend JWT
- * exchange, user upsert) is tracked as S3.1.
+ * starts cleanly in dev without credentials. On sign-in, the backend upserts
+ * the user and returns a JWT signed with the shared SECRET_KEY.
  */
 import NextAuth from 'next-auth'
-import type { NextAuthConfig } from 'next-auth'
+import type { NextAuthConfig, User } from 'next-auth'
 import GitHub from 'next-auth/providers/github'
 import Google from 'next-auth/providers/google'
+
+const backendUrl = process.env.BACKEND_URL ?? 'http://localhost:8000'
 
 const providers: NextAuthConfig['providers'] = []
 
@@ -30,19 +32,70 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
   )
 }
 
+interface SyncResponse {
+  user_id: string
+  access_token: string
+}
+
+async function syncUserWithBackend(user: User, provider: string, providerId: string) {
+  const res = await fetch(`${backendUrl}/api/auth/sync`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: user.email,
+      name: user.name ?? user.email,
+      avatar_url: user.image ?? null,
+      provider,
+      provider_id: providerId,
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error(`Auth sync failed: ${res.status}`)
+  }
+
+  return (await res.json()) as SyncResponse
+}
+
 const config: NextAuthConfig = {
   providers,
+  secret: process.env.NEXTAUTH_SECRET,
+  session: { strategy: 'jwt' },
+  pages: {
+    signIn: '/auth/signin',
+  },
   callbacks: {
-    jwt({ token, account }) {
-      // Persist the OAuth provider's access token so we can forward it to the
-      // backend as a Bearer token. S3.1 will replace this with a backend-issued
-      // JWT once the /api/auth/callback exchange endpoint is implemented.
-      if (account?.access_token) {
-        token.accessToken = account.access_token
+    async signIn({ user, account }) {
+      if (!account?.providerAccountId || !user.email) {
+        return false
+      }
+
+      try {
+        const data = await syncUserWithBackend(
+          user,
+          account.provider,
+          account.providerAccountId,
+        )
+        user.id = data.user_id
+        user.accessToken = data.access_token
+        return true
+      } catch {
+        return false
+      }
+    },
+    jwt({ token, user }) {
+      if (user?.id) {
+        token.sub = user.id
+      }
+      if (user?.accessToken) {
+        token.accessToken = user.accessToken
       }
       return token
     },
     session({ session, token }) {
+      if (token.sub) {
+        session.user.id = token.sub
+      }
       if (token.accessToken) {
         session.accessToken = token.accessToken as string
       }

--- a/frontend/src/components/auth/SignInForm.tsx
+++ b/frontend/src/components/auth/SignInForm.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { signIn } from 'next-auth/react'
+import { Button } from '@/components/ui/button'
+
+interface SignInFormProps {
+  hasGitHub: boolean
+  hasGoogle: boolean
+}
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className="size-4 fill-current">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  )
+}
+
+function GoogleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden className="size-4">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
+export function SignInForm({ hasGitHub, hasGoogle }: SignInFormProps) {
+  if (!hasGitHub && !hasGoogle) {
+    return (
+      <p className="text-center text-sm text-muted-foreground">
+        No OAuth providers configured. Set GITHUB_CLIENT_ID/SECRET or
+        GOOGLE_CLIENT_ID/SECRET in your environment.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {hasGitHub ? (
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => signIn('github', { callbackUrl: '/channels' })}
+        >
+          <GitHubIcon />
+          Continue with GitHub
+        </Button>
+      ) : null}
+
+      {hasGoogle ? (
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => signIn('google', { callbackUrl: '/channels' })}
+        >
+          <GoogleIcon />
+          Continue with Google
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/ChannelSidebar.tsx
+++ b/frontend/src/components/layout/ChannelSidebar.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { DMSection } from '@/components/layout/DMSection'
+import { SidebarFooter } from '@/components/layout/SidebarFooter'
 import type { Channel } from '@/types'
 
 interface ChannelItemProps {
@@ -93,6 +94,7 @@ export function ChannelSidebar() {
       </div>
 
       <DMSection />
+      <SidebarFooter />
     </nav>
   )
 }

--- a/frontend/src/components/layout/SidebarFooter.tsx
+++ b/frontend/src/components/layout/SidebarFooter.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { signOut, useSession } from 'next-auth/react'
+import { LogOut } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+function initials(name: string | null | undefined, email: string | null | undefined) {
+  if (name) {
+    return name
+      .split(' ')
+      .map((part) => part[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase()
+  }
+  return email?.[0]?.toUpperCase() ?? '?'
+}
+
+export function SidebarFooter() {
+  const { data: session } = useSession()
+  const user = session?.user
+
+  if (!user) {
+    return null
+  }
+
+  return (
+    <div className="mt-auto border-t px-2 py-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="User menu"
+        >
+          <Avatar size="sm">
+            {user.image ? <AvatarImage src={user.image} alt={user.name ?? ''} /> : null}
+            <AvatarFallback>{initials(user.name, user.email)}</AvatarFallback>
+          </Avatar>
+          <span className="min-w-0 flex-1 truncate text-left font-medium">
+            {user.name ?? user.email}
+          </span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="top" className="w-56">
+          <DropdownMenuLabel className="font-normal">
+            <div className="flex flex-col gap-0.5">
+              <span className="truncate font-medium">{user.name}</span>
+              <span className="truncate text-xs text-muted-foreground">{user.email}</span>
+            </div>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => signOut({ callbackUrl: '/auth/signin' })}
+            className="cursor-pointer"
+          >
+            <LogOut className="size-4" />
+            Sign out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,14 @@
+import { auth } from '@/auth'
+import { NextResponse } from 'next/server'
+
+export default auth((req) => {
+  if (!req.auth) {
+    const signInUrl = new URL('/auth/signin', req.nextUrl.origin)
+    signInUrl.searchParams.set('callbackUrl', req.nextUrl.pathname)
+    return NextResponse.redirect(signInUrl)
+  }
+})
+
+export const config = {
+  matcher: ['/channels/:path*'],
+}

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -1,9 +1,16 @@
 import type { DefaultSession } from 'next-auth'
 
 declare module 'next-auth' {
+  interface User {
+    accessToken?: string
+  }
+
   interface Session extends DefaultSession {
     /** Backend JWT forwarded as Authorization: Bearer on all API calls. */
     accessToken?: string
+    user: {
+      id: string
+    } & DefaultSession['user']
   }
 }
 


### PR DESCRIPTION
Wire NextAuth sign-in to backend user upsert and JWT issuance so API and WebSocket calls authenticate with a shared SECRET_KEY token. Protect /channels routes, add the sign-in UI, and expose sign-out in the sidebar.